### PR TITLE
Added an example for an older version to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ PINECONE_ENVIRONMENT=
 
 4. In the `config` folder, replace the `PINECONE_INDEX_NAME` and `PINECONE_NAME_SPACE` with your own details from your pinecone dashboard.
 
-5. In `utils/makechain.ts` chain change the `QA_PROMPT` for your own usecase. Change `modelName` in `new OpenAIChat` to a different api model if you don't have access to `gpt-4`.
+5. In `utils/makechain.ts` chain change the `QA_PROMPT` for your own usecase. Change `modelName` in `new OpenAIChat` to a different api model if you don't have access to `gpt-4`. See [the OpenAI docs](https://platform.openai.com/docs/models/model-endpoint-compatibility) for a list of supported `modelName`s. For example you could use `gpt-3.5-turbo` if you do not have access to `gpt-4`, yet.
 
 ## Convert your PDF to embeddings
 

--- a/utils/makechain.ts
+++ b/utils/makechain.ts
@@ -36,7 +36,7 @@ export const makeChain = (
   const docChain = loadQAChain(
     new OpenAIChat({
       temperature: 0,
-      modelName: 'gpt-4', //change this to older versions if you don't have access to gpt-4
+      modelName: 'gpt-4', //change this to older versions (e.g. gpt-3.5-turbo) if you don't have access to gpt-4
       streaming: Boolean(onTokenStream),
       callbackManager: onTokenStream
         ? CallbackManager.fromHandlers({


### PR DESCRIPTION
Hi,

thanks again for the implementation. I was looking for a solution like this. I ran into the same error as #5 and stumbled upon [these docs](https://platform.openai.com/docs/models/model-endpoint-compatibility) after some googling. Changing the name to `gpt-3.5-turbo` worked for me.

This PR updated the Readme and `makechain.ts` to include the reference to the working model (and the docs). 