### PR TITLE
Remove the duplicate section "engines" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,6 @@
     "tsx": "^3.12.3",
     "typescript": "^4.9.5"
   },
-  "engines": {
-    "node": ">=18"
-  },
   "keywords": [
     "starter",
     "gpt4",


### PR DESCRIPTION
There are two sections of the configurations of "engines" that requires node>=18 in file package.json, separately at line 5 and 49 Remove the second one